### PR TITLE
[SYCL][SPIR-V Backend] Add SPIR-V backend support inside clang-sycl-linker

### DIFF
--- a/clang/test/Driver/clang-sycl-linker-test.cpp
+++ b/clang/test/Driver/clang-sycl-linker-test.cpp
@@ -6,12 +6,12 @@
 // RUN: clang-sycl-linker --dry-run -triple spirv64 %t_1.bc %t_2.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=SIMPLE
 // SIMPLE: "{{.*}}llvm-link{{.*}}" {{.*}}.bc {{.*}}.bc -o [[FIRSTLLVMLINKOUT:.*]].bc --suppress-warnings
-// SIMPLE-NEXT: "{{.*}}llvm-spirv{{.*}}" {{.*}}-o a.spv [[FIRSTLLVMLINKOUT]].bc
+// SIMPLE-NEXT: LLVM-SPIRV-Backend: input: {{.*}}.bc, output: a.spv
 //
 // Test that llvm-link is not called when only one input is present.
 // RUN: clang-sycl-linker --dry-run -triple spirv64 %t_1.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=SIMPLE-NO-LINK
-// SIMPLE-NO-LINK: "{{.*}}llvm-spirv{{.*}}" {{.*}}-o a.spv {{.*}}.bc
+// SIMPLE-NO-LINK: LLVM-SPIRV-Backend: input: {{.*}}.bc, output: a.spv
 //
 // Test a simple case with device library files specified.
 // RUN: touch %T/lib1.bc
@@ -20,7 +20,7 @@
 // RUN:   | FileCheck %s --check-prefix=DEVLIBS
 // DEVLIBS: "{{.*}}llvm-link{{.*}}" {{.*}}.bc {{.*}}.bc -o [[FIRSTLLVMLINKOUT:.*]].bc --suppress-warnings
 // DEVLIBS-NEXT: "{{.*}}llvm-link{{.*}}" -only-needed [[FIRSTLLVMLINKOUT]].bc {{.*}}lib1.bc {{.*}}lib2.bc -o [[SECONDLLVMLINKOUT:.*]].bc --suppress-warnings
-// DEVLIBS-NEXT: "{{.*}}llvm-spirv{{.*}}" {{.*}}-o a.spv [[SECONDLLVMLINKOUT]].bc
+// DEVLIBS-NEXT: LLVM-SPIRV-Backend: input: [[SECONDLLVMLINKOUT]].bc, output: a.spv
 //
 // Test a simple case with .o (fat object) as input.
 // TODO: Remove this test once fat object support is added.
@@ -36,13 +36,3 @@
 // RUN: not clang-sycl-linker --dry-run -triple spirv64 %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc,lib3.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=DEVLIBSERR2
 // DEVLIBSERR2: '{{.*}}lib3.bc' SYCL device library file is not found
-//
-// Test if correct set of llvm-spirv options are emitted for windows environment.
-// RUN: clang-sycl-linker --dry-run -triple spirv64 --is-windows-msvc-env %t_1.bc %t_2.bc -o a.spv 2>&1 \
-// RUN:   | FileCheck %s --check-prefix=LLVMOPTSWIN
-// LLVMOPTSWIN: -spirv-debug-info-version=ocl-100 -spirv-allow-extra-diexpressions -spirv-allow-unknown-intrinsics=llvm.genx. -spirv-ext=
-//
-// Test if correct set of llvm-spirv options are emitted for linux environment.
-// RUN: clang-sycl-linker --dry-run -triple spirv64  %t_1.bc %t_2.bc -o a.spv 2>&1 \
-// RUN:   | FileCheck %s --check-prefix=LLVMOPTSLIN
-// LLVMOPTSLIN: -spirv-debug-info-version=nonsemantic-shader-200 -spirv-allow-unknown-intrinsics=llvm.genx. -spirv-ext=

--- a/clang/test/Driver/clang-sycl-linker-test.cpp
+++ b/clang/test/Driver/clang-sycl-linker-test.cpp
@@ -6,12 +6,12 @@
 // RUN: clang-sycl-linker --dry-run %t_1.bc %t_2.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=SIMPLE
 // SIMPLE: "{{.*}}llvm-link{{.*}}" {{.*}}.bc {{.*}}.bc -o [[FIRSTLLVMLINKOUT:.*]].bc --suppress-warnings
-// SIMPLE-NEXT: LLVM-SPIRV-Backend: input: {{.*}}.bc, output: a.spv
+// SIMPLE-NEXT: SPIR-V Backend: input: {{.*}}.bc, output: a.spv
 //
 // Test that llvm-link is not called when only one input is present.
 // RUN: clang-sycl-linker --dry-run %t_1.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=SIMPLE-NO-LINK
-// SIMPLE-NO-LINK: LLVM-SPIRV-Backend: input: {{.*}}.bc, output: a.spv
+// SIMPLE-NO-LINK: SPIR-V Backend: input: {{.*}}.bc, output: a.spv
 //
 // Test a simple case with device library files specified.
 // RUN: touch %T/lib1.bc
@@ -20,7 +20,7 @@
 // RUN:   | FileCheck %s --check-prefix=DEVLIBS
 // DEVLIBS: "{{.*}}llvm-link{{.*}}" {{.*}}.bc {{.*}}.bc -o [[FIRSTLLVMLINKOUT:.*]].bc --suppress-warnings
 // DEVLIBS-NEXT: "{{.*}}llvm-link{{.*}}" -only-needed [[FIRSTLLVMLINKOUT]].bc {{.*}}lib1.bc {{.*}}lib2.bc -o [[SECONDLLVMLINKOUT:.*]].bc --suppress-warnings
-// DEVLIBS-NEXT: LLVM-SPIRV-Backend: input: [[SECONDLLVMLINKOUT]].bc, output: a.spv
+// DEVLIBS-NEXT: SPIR-V Backend: input: [[SECONDLLVMLINKOUT]].bc, output: a.spv
 //
 // Test a simple case with .o (fat object) as input.
 // TODO: Remove this test once fat object support is added.

--- a/clang/test/Driver/clang-sycl-linker-test.cpp
+++ b/clang/test/Driver/clang-sycl-linker-test.cpp
@@ -3,20 +3,20 @@
 // Test a simple case without arguments.
 // RUN: %clangxx -emit-llvm -c %s -o %t_1.bc
 // RUN: %clangxx -emit-llvm -c %s -o %t_2.bc
-// RUN: clang-sycl-linker --dry-run -triple spirv64 %t_1.bc %t_2.bc -o a.spv 2>&1 \
+// RUN: clang-sycl-linker --dry-run %t_1.bc %t_2.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=SIMPLE
 // SIMPLE: "{{.*}}llvm-link{{.*}}" {{.*}}.bc {{.*}}.bc -o [[FIRSTLLVMLINKOUT:.*]].bc --suppress-warnings
 // SIMPLE-NEXT: LLVM-SPIRV-Backend: input: {{.*}}.bc, output: a.spv
 //
 // Test that llvm-link is not called when only one input is present.
-// RUN: clang-sycl-linker --dry-run -triple spirv64 %t_1.bc -o a.spv 2>&1 \
+// RUN: clang-sycl-linker --dry-run %t_1.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=SIMPLE-NO-LINK
 // SIMPLE-NO-LINK: LLVM-SPIRV-Backend: input: {{.*}}.bc, output: a.spv
 //
 // Test a simple case with device library files specified.
 // RUN: touch %T/lib1.bc
 // RUN: touch %T/lib2.bc
-// RUN: clang-sycl-linker --dry-run -triple spirv64 %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc -o a.spv 2>&1 \
+// RUN: clang-sycl-linker --dry-run %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=DEVLIBS
 // DEVLIBS: "{{.*}}llvm-link{{.*}}" {{.*}}.bc {{.*}}.bc -o [[FIRSTLLVMLINKOUT:.*]].bc --suppress-warnings
 // DEVLIBS-NEXT: "{{.*}}llvm-link{{.*}}" -only-needed [[FIRSTLLVMLINKOUT]].bc {{.*}}lib1.bc {{.*}}lib2.bc -o [[SECONDLLVMLINKOUT:.*]].bc --suppress-warnings
@@ -25,14 +25,14 @@
 // Test a simple case with .o (fat object) as input.
 // TODO: Remove this test once fat object support is added.
 // RUN: %clangxx -c %s -o %t.o
-// RUN: not clang-sycl-linker --dry-run -triple spirv64 %t.o -o a.spv 2>&1 \
+// RUN: not clang-sycl-linker --dry-run %t.o -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=FILETYPEERROR
 // FILETYPEERROR: Unsupported file type
 //
 // Test to see if device library related errors are emitted.
-// RUN: not clang-sycl-linker --dry-run -triple spirv64 %t_1.bc %t_2.bc --library-path=%T --device-libs= -o a.spv 2>&1 \
+// RUN: not clang-sycl-linker --dry-run %t_1.bc %t_2.bc --library-path=%T --device-libs= -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=DEVLIBSERR1
 // DEVLIBSERR1: Number of device library files cannot be zero
-// RUN: not clang-sycl-linker --dry-run -triple spirv64 %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc,lib3.bc -o a.spv 2>&1 \
+// RUN: not clang-sycl-linker --dry-run %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc,lib3.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=DEVLIBSERR2
 // DEVLIBSERR2: '{{.*}}lib3.bc' SYCL device library file is not found

--- a/clang/test/Driver/clang-sycl-linker-test.cpp
+++ b/clang/test/Driver/clang-sycl-linker-test.cpp
@@ -3,20 +3,20 @@
 // Test a simple case without arguments.
 // RUN: %clangxx -emit-llvm -c %s -o %t_1.bc
 // RUN: %clangxx -emit-llvm -c %s -o %t_2.bc
-// RUN: clang-sycl-linker --dry-run %t_1.bc %t_2.bc -o a.spv 2>&1 \
+// RUN: clang-sycl-linker --dry-run -v %t_1.bc %t_2.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=SIMPLE
 // SIMPLE: "{{.*}}llvm-link{{.*}}" {{.*}}.bc {{.*}}.bc -o [[FIRSTLLVMLINKOUT:.*]].bc --suppress-warnings
 // SIMPLE-NEXT: SPIR-V Backend: input: {{.*}}.bc, output: a.spv
 //
 // Test that llvm-link is not called when only one input is present.
-// RUN: clang-sycl-linker --dry-run %t_1.bc -o a.spv 2>&1 \
+// RUN: clang-sycl-linker --dry-run -v %t_1.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=SIMPLE-NO-LINK
 // SIMPLE-NO-LINK: SPIR-V Backend: input: {{.*}}.bc, output: a.spv
 //
 // Test a simple case with device library files specified.
 // RUN: touch %T/lib1.bc
 // RUN: touch %T/lib2.bc
-// RUN: clang-sycl-linker --dry-run %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc -o a.spv 2>&1 \
+// RUN: clang-sycl-linker --dry-run -v %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=DEVLIBS
 // DEVLIBS: "{{.*}}llvm-link{{.*}}" {{.*}}.bc {{.*}}.bc -o [[FIRSTLLVMLINKOUT:.*]].bc --suppress-warnings
 // DEVLIBS-NEXT: "{{.*}}llvm-link{{.*}}" -only-needed [[FIRSTLLVMLINKOUT]].bc {{.*}}lib1.bc {{.*}}lib2.bc -o [[SECONDLLVMLINKOUT:.*]].bc --suppress-warnings
@@ -25,7 +25,7 @@
 // Test a simple case with .o (fat object) as input.
 // TODO: Remove this test once fat object support is added.
 // RUN: %clangxx -c %s -o %t.o
-// RUN: not clang-sycl-linker --dry-run %t.o -o a.spv 2>&1 \
+// RUN: not clang-sycl-linker --dry-run -v %t.o -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=FILETYPEERROR
 // FILETYPEERROR: Unsupported file type
 //

--- a/clang/test/Driver/clang-sycl-linker-test.cpp
+++ b/clang/test/Driver/clang-sycl-linker-test.cpp
@@ -1,22 +1,22 @@
 // Tests the clang-sycl-linker tool.
 //
 // Test a simple case without arguments.
-// RUN: %clangxx -emit-llvm -c %s -o %t_1.bc
-// RUN: %clangxx -emit-llvm -c %s -o %t_2.bc
-// RUN: clang-sycl-linker --dry-run -v %t_1.bc %t_2.bc -o a.spv 2>&1 \
+// RUN: %clangxx -emit-llvm -c -target spirv64 %s -o %t_1.bc
+// RUN: %clangxx -emit-llvm -c -target spirv64 %s -o %t_2.bc
+// RUN: clang-sycl-linker --dry-run -v -triple=spirv64 %t_1.bc %t_2.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=SIMPLE
 // SIMPLE: "{{.*}}llvm-link{{.*}}" {{.*}}.bc {{.*}}.bc -o [[FIRSTLLVMLINKOUT:.*]].bc --suppress-warnings
 // SIMPLE-NEXT: SPIR-V Backend: input: {{.*}}.bc, output: a.spv
 //
 // Test that llvm-link is not called when only one input is present.
-// RUN: clang-sycl-linker --dry-run -v %t_1.bc -o a.spv 2>&1 \
+// RUN: clang-sycl-linker --dry-run -v -triple=spirv64 %t_1.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=SIMPLE-NO-LINK
 // SIMPLE-NO-LINK: SPIR-V Backend: input: {{.*}}.bc, output: a.spv
 //
 // Test a simple case with device library files specified.
 // RUN: touch %T/lib1.bc
 // RUN: touch %T/lib2.bc
-// RUN: clang-sycl-linker --dry-run -v %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc -o a.spv 2>&1 \
+// RUN: clang-sycl-linker --dry-run -v -triple=spirv64 %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=DEVLIBS
 // DEVLIBS: "{{.*}}llvm-link{{.*}}" {{.*}}.bc {{.*}}.bc -o [[FIRSTLLVMLINKOUT:.*]].bc --suppress-warnings
 // DEVLIBS-NEXT: "{{.*}}llvm-link{{.*}}" -only-needed [[FIRSTLLVMLINKOUT]].bc {{.*}}lib1.bc {{.*}}lib2.bc -o [[SECONDLLVMLINKOUT:.*]].bc --suppress-warnings
@@ -24,15 +24,15 @@
 //
 // Test a simple case with .o (fat object) as input.
 // TODO: Remove this test once fat object support is added.
-// RUN: %clangxx -c %s -o %t.o
-// RUN: not clang-sycl-linker --dry-run -v %t.o -o a.spv 2>&1 \
+// RUN: %clangxx -c  -target spirv64 %s -o %t.o
+// RUN: not clang-sycl-linker --dry-run -v -triple=spirv64 %t.o -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=FILETYPEERROR
 // FILETYPEERROR: Unsupported file type
 //
 // Test to see if device library related errors are emitted.
-// RUN: not clang-sycl-linker --dry-run %t_1.bc %t_2.bc --library-path=%T --device-libs= -o a.spv 2>&1 \
+// RUN: not clang-sycl-linker --dry-run -triple=spirv64 %t_1.bc %t_2.bc --library-path=%T --device-libs= -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=DEVLIBSERR1
 // DEVLIBSERR1: Number of device library files cannot be zero
-// RUN: not clang-sycl-linker --dry-run %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc,lib3.bc -o a.spv 2>&1 \
+// RUN: not clang-sycl-linker --dry-run -triple=spirv64 %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc,lib3.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=DEVLIBSERR2
 // DEVLIBSERR2: '{{.*}}lib3.bc' SYCL device library file is not found

--- a/clang/test/Driver/sycl-link-spirv-target.cpp
+++ b/clang/test/Driver/sycl-link-spirv-target.cpp
@@ -3,7 +3,7 @@
 //
 // Test that -Xlinker options are being passed to clang-sycl-linker.
 // RUN: touch %t.bc
-// RUN: %clangxx -### --target=spirv64 --sycl-link -Xlinker --llvm-spirv-path=/tmp \
-// RUN:   -Xlinker --library-path=/tmp -Xlinker --device-libs=lib1.bc,lib2.bc %t.bc 2>&1 \
+// RUN: %clangxx -### --target=spirv64 --sycl-link -Xlinker --library-path=/tmp \
+// RUN:   -Xlinker --device-libs=lib1.bc,lib2.bc %t.bc 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=XLINKEROPTS
-// XLINKEROPTS: "{{.*}}clang-sycl-linker{{.*}}" "--llvm-spirv-path=/tmp" "--library-path=/tmp" "--device-libs=lib1.bc,lib2.bc" "{{.*}}.bc" "-o" "a.out"
+// XLINKEROPTS: "{{.*}}clang-sycl-linker{{.*}}" "--library-path=/tmp" "--device-libs=lib1.bc,lib2.bc" "{{.*}}.bc" "-o" "a.out"

--- a/clang/test/Driver/sycl-link-spirv-target.cpp
+++ b/clang/test/Driver/sycl-link-spirv-target.cpp
@@ -3,7 +3,7 @@
 //
 // Test that -Xlinker options are being passed to clang-sycl-linker.
 // RUN: touch %t.bc
-// RUN: %clangxx -### --target=spirv64 --sycl-link -Xlinker --library-path=/tmp \
+// RUN: %clangxx -### --target=spirv64 --sycl-link -Xlinker -triple=spirv64 -Xlinker --library-path=/tmp \
 // RUN:   -Xlinker --device-libs=lib1.bc,lib2.bc %t.bc 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=XLINKEROPTS
-// XLINKEROPTS: "{{.*}}clang-sycl-linker{{.*}}" "--library-path=/tmp" "--device-libs=lib1.bc,lib2.bc" "{{.*}}.bc" "-o" "a.out"
+// XLINKEROPTS: "{{.*}}clang-sycl-linker{{.*}}" "-triple=spirv64" "--library-path=/tmp" "--device-libs=lib1.bc,lib2.bc" "{{.*}}.bc" "-o" "a.out"

--- a/clang/tools/clang-sycl-linker/CMakeLists.txt
+++ b/clang/tools/clang-sycl-linker/CMakeLists.txt
@@ -1,8 +1,10 @@
 set(LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
   BinaryFormat
+  MC
   Option
   Object
+  Target
   TargetParser
   Support
   )

--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -335,6 +335,9 @@ static Expected<StringRef> runSPIRVCodeGen(StringRef File,
   if (!M)
     return createStringError(inconvertibleErrorCode(), Err.getMessage());
 
+  Triple TargetTriple(Args.getLastArgValue(OPT_triple_EQ));
+  M->setTargetTriple(TargetTriple);
+
   // Get a handle to SPIR-V target backend.
   std::string Msg;
   const Target *T = TargetRegistry::lookupTarget(M->getTargetTriple(), Msg);
@@ -346,7 +349,7 @@ static Expected<StringRef> runSPIRVCodeGen(StringRef File,
   std::optional<Reloc::Model> RM;
   std::optional<CodeModel::Model> CM;
   std::unique_ptr<TargetMachine> TM(
-      T->createTargetMachine(M->getTargetTriple().str(), /* CPU */ "",
+      T->createTargetMachine(M->getTargetTriple().getTriple(), /* CPU */ "",
                              /* Features */ "", Options, RM, CM));
   if (!TM)
     return createStringError("Could not allocate target machine!");

--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -325,7 +325,7 @@ static Expected<StringRef> runSPIRVCodeGen(StringRef File,
                                            const ArgList &Args) {
   llvm::TimeTraceScope TimeScope("SPIR-V code generation");
   if (Verbose || DryRun) {
-    errs() << formatv("LLVM-SPIRV-Backend: input: {0}, output: {1}\n", File,
+    errs() << formatv("SPIR-V Backend: input: {0}, output: {1}\n", File,
                       OutputFile);
     if (DryRun)
       return OutputFile;
@@ -340,7 +340,7 @@ static Expected<StringRef> runSPIRVCodeGen(StringRef File,
   if (!M)
     return createStringError(inconvertibleErrorCode(), Err.getMessage());
 
-  static const std::string DefaultTriple = "spirv64v1.6-unknown-unknown";
+  static const std::string DefaultTriple = "spirv64-unknown-unknown";
   Triple TargetTriple(M->getTargetTriple());
   if (TargetTriple.getTriple().empty())
     TargetTriple.setTriple(DefaultTriple);
@@ -356,8 +356,9 @@ static Expected<StringRef> runSPIRVCodeGen(StringRef File,
   TargetOptions Options;
   std::optional<Reloc::Model> RM;
   std::optional<CodeModel::Model> CM;
-  std::unique_ptr<TargetMachine> TM(T->createTargetMachine(
-      M->getTargetTriple().str(), "", "", Options, RM, CM));
+  std::unique_ptr<TargetMachine> TM(
+      T->createTargetMachine(M->getTargetTriple().str(), /* CPU */ "",
+                             /* Features */ "", Options, RM, CM));
   if (!TM)
     return createStringError("Could not allocate target machine!");
 
@@ -374,7 +375,7 @@ static Expected<StringRef> runSPIRVCodeGen(StringRef File,
   CodeGenPasses.add(new TargetLibraryInfoWrapperPass(TLII));
   if (TM->addPassesToEmitFile(CodeGenPasses, *OS, nullptr,
                               CodeGenFileType::ObjectFile))
-    return createStringError("Failed to execute SPIR-V backend");
+    return createStringError("Failed to execute SPIR-V Backend");
   CodeGenPasses.run(*M);
   return OutputFile;
 }

--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -335,27 +335,13 @@ static Expected<StringRef> runSPIRVCodeGen(StringRef File,
   if (!M)
     return createStringError(inconvertibleErrorCode(), Err.getMessage());
 
-  // Update target triple for SPIR-V backend by incorporating SPIR-V version.
-  StringRef Version = Args.getLastArgValue(OPT_spirv_version_EQ);
-  static const std::string TargetTripleStr =
-      StringSwitch<std::string>(Version)
-          .Case("1.0", "spirv64v1.0-unknown-unknown")
-          .Case("1.1", "spirv64v1.1-unknown-unknown")
-          .Case("1.2", "spirv64v1.2-unknown-unknown")
-          .Case("1.3", "spirv64v1.3-unknown-unknown")
-          .Case("1.4", "spirv64v1.4-unknown-unknown")
-          .Case("1.5", "spirv64v1.5-unknown-unknown")
-          .Case("1.6", "spirv64v1.6-unknown-unknown")
-          .Default("spirv64-unknown-unknown");
-  M->setTargetTriple(llvm::Triple(TargetTripleStr));
-
   // Get a handle to SPIR-V target backend.
   std::string Msg;
   const Target *T = TargetRegistry::lookupTarget(M->getTargetTriple(), Msg);
   if (!T)
     return createStringError(Msg + ": " + M->getTargetTriple().str());
 
-  // Allocate SPIR-V target machine
+  // Allocate SPIR-V target machine.
   TargetOptions Options;
   std::optional<Reloc::Model> RM;
   std::optional<CodeModel::Model> CM;
@@ -375,7 +361,7 @@ static Expected<StringRef> runSPIRVCodeGen(StringRef File,
     return errorCodeToError(EC);
   auto OS = std::make_unique<llvm::raw_fd_ostream>(FD, true);
 
-  // Run SPIR-V codegen passes to generate SPIR-V file
+  // Run SPIR-V codegen passes to generate SPIR-V file.
   legacy::PassManager CodeGenPasses;
   TargetLibraryInfoImpl TLII(M->getTargetTriple());
   CodeGenPasses.add(new TargetLibraryInfoWrapperPass(TLII));

--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -368,9 +368,8 @@ static Expected<StringRef> runSPIRVCodeGen(StringRef File,
   TargetOptions Options;
   std::optional<Reloc::Model> RM;
   std::optional<CodeModel::Model> CM;
-  std::unique_ptr<TargetMachine> TM(
-      T->createTargetMachine(M->getTargetTriple().str(), "", "", Options, RM,
-                             CM));
+  std::unique_ptr<TargetMachine> TM(T->createTargetMachine(
+      M->getTargetTriple().str(), "", "", Options, RM, CM));
   if (!TM)
     return createStringError("Could not allocate target machine!");
 

--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -306,7 +306,7 @@ static Expected<StringRef> linkDeviceLibFiles(StringRef InputFile,
 }
 
 /// Run LLVM to SPIR-V translation.
-/// Converts 'File' from LLVM bitcode to SPIR-V format using SPIR-V backend,
+/// Converts 'File' from LLVM bitcode to SPIR-V format using SPIR-V backend.
 /// 'Args' encompasses all arguments required for linking device code and will
 /// be parsed to generate options required to be passed into the backend.
 static Expected<StringRef> runLLVMSPIRVBackend(StringRef File,

--- a/clang/tools/clang-sycl-linker/SYCLLinkOpts.td
+++ b/clang/tools/clang-sycl-linker/SYCLLinkOpts.td
@@ -24,10 +24,14 @@ def device_libs_EQ : CommaJoined<["--", "-"], "device-libs=">,
   Flags<[LinkerOnlyOption]>,
   HelpText<"A comma separated list of device libraries that are linked during the device link.">;
 
-def triple : Separate<["--", "-"], "triple">,
-  HelpText<"The device target triple">;
-def arch : Separate<["--", "-"], "arch">,
-  HelpText<"Specify the name of the target architecture.">;
+def arch_EQ : Joined<["--", "-"], "arch=">,
+              Flags<[LinkerOnlyOption]>,
+              MetaVarName<"<arch>">,
+              HelpText<"The device subarchitecture">;
+def triple_EQ : Joined<["--", "-"], "triple=">,
+                Flags<[LinkerOnlyOption]>,
+                MetaVarName<"<triple>">,
+                HelpText<"The device target triple">;
 
 def save_temps : Flag<["--", "-"], "save-temps">,
   Flags<[LinkerOnlyOption]>, HelpText<"Save intermediate results">;

--- a/clang/tools/clang-sycl-linker/SYCLLinkOpts.td
+++ b/clang/tools/clang-sycl-linker/SYCLLinkOpts.td
@@ -24,11 +24,6 @@ def device_libs_EQ : CommaJoined<["--", "-"], "device-libs=">,
   Flags<[LinkerOnlyOption]>,
   HelpText<"A comma separated list of device libraries that are linked during the device link.">;
 
-def triple : Joined<["--"], "triple">,
-  HelpText<"The device target triple">;
-def arch : Separate<["--", "-"], "arch">,
-  HelpText<"Specify the name of the target architecture.">;
-
 def save_temps : Flag<["--", "-"], "save-temps">,
   Flags<[LinkerOnlyOption]>, HelpText<"Save intermediate results">;
 

--- a/clang/tools/clang-sycl-linker/SYCLLinkOpts.td
+++ b/clang/tools/clang-sycl-linker/SYCLLinkOpts.td
@@ -24,6 +24,11 @@ def device_libs_EQ : CommaJoined<["--", "-"], "device-libs=">,
   Flags<[LinkerOnlyOption]>,
   HelpText<"A comma separated list of device libraries that are linked during the device link.">;
 
+def triple : Separate<["--", "-"], "triple">,
+  HelpText<"The device target triple">;
+def arch : Separate<["--", "-"], "arch">,
+  HelpText<"Specify the name of the target architecture.">;
+
 def save_temps : Flag<["--", "-"], "save-temps">,
   Flags<[LinkerOnlyOption]>, HelpText<"Save intermediate results">;
 

--- a/clang/tools/clang-sycl-linker/SYCLLinkOpts.td
+++ b/clang/tools/clang-sycl-linker/SYCLLinkOpts.td
@@ -46,6 +46,10 @@ def llvm_spirv_path_EQ : Joined<["--"], "llvm-spirv-path=">,
   Flags<[LinkerOnlyOption]>, MetaVarName<"<dir>">,
   HelpText<"Set the system llvm-spirv path">;
 
+def spirv_version_EQ : Joined<["--"], "spirv-version=">,
+                       Flags<[LinkerOnlyOption]>,
+                       HelpText<"Set SPIR-V version">;
+
 // Options to pass to llvm-spirv tool
 def llvm_spirv_options_EQ : Joined<["--", "-"], "llvm-spirv-options=">,
   Flags<[LinkerOnlyOption]>,

--- a/clang/tools/clang-sycl-linker/SYCLLinkOpts.td
+++ b/clang/tools/clang-sycl-linker/SYCLLinkOpts.td
@@ -46,10 +46,6 @@ def llvm_spirv_path_EQ : Joined<["--"], "llvm-spirv-path=">,
   Flags<[LinkerOnlyOption]>, MetaVarName<"<dir>">,
   HelpText<"Set the system llvm-spirv path">;
 
-def spirv_version_EQ : Joined<["--"], "spirv-version=">,
-                       Flags<[LinkerOnlyOption]>,
-                       HelpText<"Set SPIR-V version">;
-
 // Options to pass to llvm-spirv tool
 def llvm_spirv_options_EQ : Joined<["--", "-"], "llvm-spirv-options=">,
   Flags<[LinkerOnlyOption]>,


### PR DESCRIPTION
This PR does the following:
1. Use SPIR-V backend to do LLVM to SPIR-V translation inside clang-sycl-linker
2. Remove llvm-spirv translator from clang-sycl-linker

Currently, all SPIR-V extensions are enabled for SYCL compilation flow. This will be updated in subsequent commits, if needed.

Thanks